### PR TITLE
feat: Add GitHub workflow to build and push Docker images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,6 +1,7 @@
 name: Build and push images
 
 on:
+  workflow_dispatch: # Manual trigger from GitHub UI
   push:
     branches: [main]
     paths:

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,112 @@
+name: Build and push images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "prestashop/Dockerfile.*"
+      - "prestashop/Caddyfile"
+      - "prestashop/static/**"
+      - "prestashop/src/**"
+      - "prestashop/Prestashop.prod.entrypoint.sh"
+      - ".github/workflows/build-push.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      prestashop: ${{ steps.filter.outputs.prestashop }}
+      caddy: ${{ steps.filter.outputs.caddy }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            prestashop:
+              - 'prestashop/Dockerfile.prestashop'
+              - 'prestashop/src/**'
+              - 'prestashop/Prestashop.prod.entrypoint.sh'
+            caddy:
+              - 'prestashop/Dockerfile.caddy'
+              - 'prestashop/Caddyfile'
+              - 'prestashop/static/**'
+
+  build:
+    name: Build ${{ matrix.component }}
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.prestashop == 'true' || needs.changes.outputs.caddy == 'true'
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - component: prestashop
+            dockerfile: prestashop/Dockerfile.prestashop
+            context: prestashop
+            target: prod
+            changes-output: prestashop
+          - component: caddy
+            dockerfile: prestashop/Dockerfile.caddy
+            context: prestashop
+            target: ""
+            changes-output: caddy
+
+    steps:
+      - name: Check if component changed
+        id: should-build
+        run: |
+          if [ "${{ matrix.changes-output }}" == "prestashop" ]; then
+            echo "build=${{ needs.changes.outputs.prestashop }}" >> $GITHUB_OUTPUT
+          else
+            echo "build=${{ needs.changes.outputs.caddy }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.should-build.outputs.build == 'true'
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.should-build.outputs.build == 'true'
+
+      - name: Login to GHCR
+        if: steps.should-build.outputs.build == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        if: steps.should-build.outputs.build == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.component }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        if: steps.should-build.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target || '' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=${{ matrix.component }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.component }}:latest
+          cache-to: type=gha,scope=${{ matrix.component }},mode=max

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -3,7 +3,7 @@ name: Build and push images
 on:
   workflow_dispatch: # Manual trigger from GitHub UI
   push:
-    branches: [main]
+    branches: [main, ci-cd-setup]
     paths:
       - "prestashop/Dockerfile.*"
       - "prestashop/Caddyfile"

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,7 +1,6 @@
 name: Build and push images
 
 on:
-  workflow_dispatch: # Manual trigger from GitHub UI
   push:
     branches: [main, ci-cd-setup]
     paths:
@@ -17,33 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    outputs:
-      prestashop: ${{ steps.filter.outputs.prestashop }}
-      caddy: ${{ steps.filter.outputs.caddy }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            prestashop:
-              - 'prestashop/Dockerfile.prestashop'
-              - 'prestashop/src/**'
-              - 'prestashop/Prestashop.prod.entrypoint.sh'
-            caddy:
-              - 'prestashop/Dockerfile.caddy'
-              - 'prestashop/Caddyfile'
-              - 'prestashop/static/**'
-
   build:
     name: Build ${{ matrix.component }}
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.prestashop == 'true' || needs.changes.outputs.caddy == 'true'
     permissions:
       contents: read
       packages: write
@@ -55,31 +30,16 @@ jobs:
             dockerfile: prestashop/Dockerfile.prestashop
             context: prestashop
             target: prod
-            changes-output: prestashop
           - component: caddy
             dockerfile: prestashop/Dockerfile.caddy
             context: prestashop
-            target: ""
-            changes-output: caddy
 
     steps:
-      - name: Check if component changed
-        id: should-build
-        run: |
-          if [ "${{ matrix.changes-output }}" == "prestashop" ]; then
-            echo "build=${{ needs.changes.outputs.prestashop }}" >> $GITHUB_OUTPUT
-          else
-            echo "build=${{ needs.changes.outputs.caddy }}" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.should-build.outputs.build == 'true'
 
       - uses: docker/setup-buildx-action@v3
-        if: steps.should-build.outputs.build == 'true'
 
       - name: Login to GHCR
-        if: steps.should-build.outputs.build == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -87,7 +47,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker metadata
-        if: steps.should-build.outputs.build == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -98,7 +57,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        if: steps.should-build.outputs.build == 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -2,7 +2,7 @@ name: Build and push images
 
 on:
   push:
-    branches: [main, ci-cd-setup]
+    branches: [main]
     paths:
       - "prestashop/Dockerfile.*"
       - "prestashop/Caddyfile"


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow to automatically build and push Docker images when relevant files change.

### What changed?

Created a new GitHub Actions workflow file (`.github/workflows/build-push.yaml`) that:
- Triggers on pushes to the `main` branch when specific PrestaShop-related files are modified
- Builds and pushes two Docker images: `prestashop` and `caddy`
- Uses Docker Buildx with caching for efficient builds
- Pushes images to GitHub Container Registry (GHCR) with appropriate tags (SHA, branch name, and latest)
- Implements concurrency controls to prevent parallel workflow runs

### How to test?

1. Push changes to any of the monitored paths in the `main` branch
2. Verify the workflow runs successfully in the Actions tab
3. Check that the Docker images are properly pushed to GHCR with the expected tags
4. Pull and run the images to ensure they function correctly

### Why make this change?

This automation ensures that Docker images are consistently built and published whenever relevant source files change, eliminating manual build steps and ensuring the latest code is always available in the container registry. This improves the development workflow and deployment process.