### PR TITLE
fix: Enhance database restore script for compatibility with older MySql

### DIFF
--- a/prestashop/backup/db.sh
+++ b/prestashop/backup/db.sh
@@ -98,11 +98,15 @@ case "$1" in
     # Convert MariaDB 10.11+ collations to MySQL 5.7 compatible ones
     if [ "$IN_CONTAINER" = true ]; then
       openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:"$DB_BACKUP_KEY" -in "$FILE" | gunzip | \
-        sed 's/utf8mb4_uca1400_ai_ci/utf8mb4_unicode_ci/g' | \
+        sed -e 's/utf8mb4_uca1400_ai_ci/utf8mb4_unicode_ci/g' \
+            -e 's/utf8mb3_uca1400_ai_ci/utf8_unicode_ci/g' \
+            -e 's/utf8mb3/utf8/g' | \
         mysql -h"$DB_HOST" -u"$DB_USER" -p"$DB_PASS" "$DB"
     else
       openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:"$DB_BACKUP_KEY" -in "$FILE" | gunzip | \
-        sed 's/utf8mb4_uca1400_ai_ci/utf8mb4_unicode_ci/g' | \
+        sed -e 's/utf8mb4_uca1400_ai_ci/utf8mb4_unicode_ci/g' \
+            -e 's/utf8mb3_uca1400_ai_ci/utf8_unicode_ci/g' \
+            -e 's/utf8mb3/utf8/g' | \
         docker exec -i "$DB_HOST" mariadb -u"$DB_USER" -p"$DB_PASS" "$DB"
     fi
     log "Database restored"


### PR DESCRIPTION
### TL;DR

Enhanced database backup restoration to handle additional MariaDB 10.11+ collations.

### What changed?

Added support for converting more MariaDB 10.11+ specific collations to MySQL 5.7 compatible ones during database restoration:
- Added conversion from `utf8mb3_uca1400_ai_ci` to `utf8_unicode_ci`
- Added conversion from `utf8mb3` to `utf8`
- Improved the `sed` command to handle multiple replacements using the `-e` flag

### How to test?

1. Create a backup from a MariaDB 10.11+ database that contains tables with `utf8mb3` collations
2. Restore the backup using the updated script
3. Verify that the database restores correctly without collation-related errors
4. Check that tables and columns using the MariaDB-specific collations are properly converted

### Why make this change?

MariaDB 10.11+ introduced additional collations like `utf8mb3_uca1400_ai_ci` that are incompatible with MySQL 5.7. This change ensures database backups from newer MariaDB versions can be successfully restored in environments running MySQL 5.7, preventing restoration failures due to collation incompatibilities.