### PR TITLE
feat: Add host.docker.internal mapping for shop.pg.wojtecs.com

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
 			]
 		}
 	},
-	"postCreateCommand": "bun run all:setup"
+	"postCreateCommand": "HOST_IP=$(getent hosts host.docker.internal | awk '{print $1}') && echo \"$HOST_IP shop.pg.wojtecs.com\" | sudo tee -a /etc/hosts && bun run all:setup"
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/prestashop/Prestashop.prod.entrypoint.sh
+++ b/prestashop/Prestashop.prod.entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Ensure cache directories exist with proper permissions
+mkdir -p /var/www/html/var/cache
+mkdir -p /var/www/html/themes/custom_action/assets/cache
+chown -R www-data:www-data /var/www/html/var/cache
+chown -R www-data:www-data /var/www/html/themes/custom_action/assets/cache
+
 PARAMS_FILE="/var/www/html/app/config/parameters.php"
 BACKUP_FILE="/tmp/db_backup.sql.gz.enc"
 

--- a/prestashop/src/.gitignore
+++ b/prestashop/src/.gitignore
@@ -7,7 +7,8 @@ app/cache/
 app/test/cache/
 
 # Theme asset cache
-themes/*/assets/cache/
+themes/*/assets/cache/*
+!themes/*/assets/cache/.gitkeep
 
 # Logs - regenerated at runtime
 var/logs/


### PR DESCRIPTION
### TL;DR

Updated the devcontainer configuration to automatically add a host entry for [shop.pg.wojtecs.com](http://shop.pg.wojtecs.com).

### What changed?

Modified the `postCreateCommand` in `.devcontainer/devcontainer.json` to:

1. Get the host machine's IP address using `getent hosts host.docker.internal`
2. Add an entry to `/etc/hosts` mapping this IP to `shop.pg.wojtecs.com`
3. Then run the existing `bun run all:setup` command

### How to test?

1. Rebuild and reopen the project in the dev container
2. Verify that `shop.pg.wojtecs.com` resolves to the host IP by running:
3. Confirm that applications can connect to services on this domain

### Why make this change?

This change simplifies local development by automatically configuring DNS resolution for the shop domain, eliminating the need for developers to manually edit their hosts file. This ensures consistent connectivity between the container and host-based services.